### PR TITLE
Use the MDL DOM and styles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_script:
   - bower install
   - polylint
 script:
-  - xvfb-run wct
+  - xvfb-run wct -l firefox
+  - xvfb-run wct -l chrome
   - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct -s 'default'; fi"
 env:
   global:

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,11 +23,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-text-field.html">
   <link rel="import" href="../paper-password-field.html">
   <link rel="import" href="../../paper-styles/color.html">
-  <link rel="import" href="../../paper-input/paper-input.html">
 
 </head>
 
 <style is="custom-style" include="demo-pages-shared-styles">
+  paper-text-field, paper-password-field {
+    width: 100%;
+  }
   .tiny {
     width: 50px;
   }
@@ -75,7 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </style>
       <template>
         <paper-text-field label="custom colors and input" class="fancy"></paper-text-field>
-        <paper-text-field label="non-focusabled, read-only like input" class="read-only" no-float-label disabled></paper-text-field>
+        <paper-text-field label="non-focusable, read-only like input" class="read-only" no-float-label disabled></paper-text-field>
       </template>
     </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-text-field.html">
   <link rel="import" href="../paper-password-field.html">
   <link rel="import" href="../../paper-styles/color.html">
+  <link rel="import" href="../../paper-input/paper-input.html">
 
 </head>
 
@@ -45,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <paper-text-field label="text input"></paper-text-field>
         <paper-password-field label="password"></paper-password-field>
         <paper-text-field label="pre-filled" value="batman"></paper-text-field>
-        <paper-text-field label="disabled input" disabled></paper-text-field>
+        <paper-text-field label="disabled input" value="batman" disabled></paper-text-field>
       </template>
     </demo-snippet>
 
@@ -74,7 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </style>
       <template>
         <paper-text-field label="custom colors and input" class="fancy"></paper-text-field>
-        <paper-text-field label="non-focusabled, read-only like input" class="read-only" disabled></paper-text-field>
+        <paper-text-field label="non-focusabled, read-only like input" class="read-only" no-float-label disabled></paper-text-field>
       </template>
     </demo-snippet>
 

--- a/paper-password-field.html
+++ b/paper-password-field.html
@@ -47,19 +47,12 @@ Custom property | Description | Default
   <template>
     <style include="paper-text-field-shared-styles"></style>
 
-    <div class="floated-label-placeholder" hidden$="[[noFloatLabel]]">&nbsp;</div>
-
-    <div class="input-content">
+    <div class="container">
       <label hidden$="[[!label]]"
-             class$="[[_computeLabelClass(noFloatLabel,alwaysFloatLabel,focused,hasContent)]]">[[label]]</label>
+          class$="[[_computeLabelClass(noFloatLabel,alwaysFloatLabel,hasContent)]]">[[label]]</label>
       <input id="input" type="password" tabindex="-1"></div>
     </div>
-
-    <div class$="underline [[_computeUnderlineClass(focused)]]">
-      <div class="unfocused-line"></div>
-      <div class="focused-line"></div>
-    </div>
-
+    
   </template>
 </dom-module>
 

--- a/paper-text-field-behavior.html
+++ b/paper-text-field-behavior.html
@@ -153,7 +153,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // TODO(noms):  When inheritance is available, investigate if these could
     // become private methods.
-    _computeLabelClass: function(noFloatLabel, alwaysFloatLabel, focused, hasContent) {
+    _computeLabelClass: function(noFloatLabel, alwaysFloatLabel, hasContent) {
       var cls = '';
       if (noFloatLabel === true) {
         return hasContent ? 'label-is-hidden' : '';
@@ -161,9 +161,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (hasContent || alwaysFloatLabel === true) {
         cls += ' label-is-floating';
-        if (focused) {
-          cls += " label-is-highlighted";
-        }
       }
       return cls;
     },

--- a/paper-text-field-shared-styles.html
+++ b/paper-text-field-shared-styles.html
@@ -47,12 +47,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border: none;
         border-bottom: 1px solid var(--paper-text-field-color, --secondary-text-color);
         margin: 0;
-        padding: 8px 0 0 0;
+        padding: 12px 0 0 0;
         width: 100%;
+        @apply(--paper-font-subhead);
         text-align: inherit;
+        line-height: inherit;
         background: 0 0;
         color: var(--paper-text-field-input-color, --primary-text-color);
-        @apply(--paper-font-subhead);
+
       }
 
       /* We manage the focus UI separately */

--- a/paper-text-field-shared-styles.html
+++ b/paper-text-field-shared-styles.html
@@ -17,8 +17,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <style>
       :host {
-        display: block;
-        padding: 8px 0;
+        display: inline-block;
+        width: 300px;
+        max-width: 100%;
       }
 
       [hidden] {
@@ -30,14 +31,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         opacity: var(--paper-text-field-disabled-opacity, 0.33);
       }
 
-      /* Restrict div contenteditable */
-      #input {
-        min-height: 24px; /* FF doesn't seem to have a default */
-        z-index: 1;
+      .container {
+        box-sizing: border-box;
+        position: relative;
+        width: 100%;
+        display: inline-block;
+        margin: 0;
+        padding: 8px 0;
+      }
 
-        /* Force single line */
-        white-space: nowrap;
-        overflow: hidden;
+      #input {
+        position: relative; /* to make a stacking context */
+        outline: none;
+        box-shadow: none;
+        border: none;
+        border-bottom: 1px solid var(--paper-text-field-color, --secondary-text-color);
+        margin: 0;
+        padding: 8px 0 0 0;
+        width: 100%;
+        text-align: inherit;
+        background: 0 0;
+        color: var(--paper-text-field-input-color, --primary-text-color);
+        @apply(--paper-font-subhead);
       }
 
       /* We manage the focus UI separately */
@@ -45,118 +60,71 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         outline: none;
       }
 
-      .floated-label-placeholder {
-        @apply(--paper-font-caption);
-      }
-
-      /*****************************
-       * Underline
-       ******************************/
-      .underline {
-        position: relative;
-      }
-
-      .focused-line {
-        height: 2px;
-
-        transform-origin: center center;
-        -webkit-transform-origin: center center;
-        transform: scale3d(0,1,1);
-        -webkit-transform: scale3d(0,1,1);
-
-        background: var(--paper-text-field-focus-color, --primary-color);
-
-        @apply(--layout-fit);
-      }
-
-      .underline.is-highlighted .focused-line {
-        -webkit-transform: none;
-        transform: none;
-        -webkit-transition: -webkit-transform 0.25s;
-        transition: transform 0.25s;
-
-        @apply(--paper-transition-easing);
-      }
-
-      .unfocused-line {
-        height: 1px;
-        background: var(--paper-text-field-color, --secondary-text-color);
-
-        @apply(--layout-fit);
-      }
-
-      :host([disabled]) .unfocused-line {
-        border-bottom: var(--paper-text-field-disabled-underline, 1px dashed);
-        border-color: var(--paper-text-field-color, --secondary-text-color);
-        background: transparent;
-      }
-
-      /*****************************
-       * Input
-       ******************************/
-      .input-content {
-        position: relative;
-        @apply(--layout-horizontal);
-        @apply(--layout-end);
-      }
-
-      .input-content #input {
-        position: relative; /* to make a stacking context */
-        outline: none;
-        box-shadow: none;
+      :host[no-float-label] #input {
         padding: 0;
-        width: 100%;
-        background: transparent;
-        border: none;
-        color: var(--paper-text-field-input-color, --primary-text-color);
-        -webkit-appearance: none;
-        text-align: inherit;
-
-        @apply(--paper-font-subhead);
       }
 
-      /*****************************
-       * Label
-       ******************************/
-      .input-content label  {
+      label {
         position: absolute;
-        top: 0;
-        right: 0;
+        bottom: 0;
         left: 0;
-        font: inherit;
-        color: var(--paper-text-field-color, --secondary-text-color);
+        right: 0;
+        top: 16px;
 
+        pointer-events: none;
+
+        display: block;
+        width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-align: left;
+        transition-duration: .2s;
+        transition-timing-function: cubic-bezier(.4,0,.2,1);
+
+        color: var(--paper-text-field-color, --secondary-text-color);
         @apply(--paper-font-common-nowrap);
         @apply(--paper-font-subhead);
+
+        transition-duration: .2s;
+        transition-timing-function: cubic-bezier(.4,0,.2,1);
       }
 
-      .input-content label.label-is-floating {
-        -webkit-transform: translateY(-75%) scale(0.75);
-        transform: translateY(-75%) scale(0.75);
-        -webkit-transition: -webkit-transform 0.25s;
-        transition: transform 0.25s;
-
-        -webkit-transform-origin: left top;
-        transform-origin: left top;
-
-        /* Since we scale to 75/100 of the size, we actually have 100/75 of the
-        original space now available */
-        width: 133%;
-
-        @apply(--paper-transition-easing);
+      :host([no-float-label]) label {
+        top: 8px;
       }
 
-      :host-context([dir="rtl"]) .input-content label.label-is-floating {
-        -webkit-transform-origin: right top;
-        transform-origin: right top;
+      label.label-is-floating {
+        font-size: 12px;
+        top: 0px;
+        visibility: visible;
       }
 
-      .input-content label.label-is-highlighted {
+      label.label-is-hidden {
+        display: none;
+      }
+
+      :host([focused]) label.label-is-floating {
         color: var(--paper-text-field-focus-color, --primary-color);
       }
 
-      .input-content label.label-is-hidden {
+      :host([focused]) label:after {
+        left: 0;
+        visibility: visible;
+        width: 100%;
+      }
+
+      /* The focused underline */
+      :host label:after {
+        background-color: var(--paper-text-field-focus-color, --primary-color);
+        bottom: 8px;
+        content: '';
+        height: 2px;
+        left: 45%;
+        position: absolute;
+        transition-duration: .2s;
+        transition-timing-function: cubic-bezier(.4,0,.2,1);
         visibility: hidden;
+        width: 8px;
       }
     </style>
 </dom-module>

--- a/paper-text-field-shared-styles.html
+++ b/paper-text-field-shared-styles.html
@@ -54,7 +54,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         line-height: inherit;
         background: 0 0;
         color: var(--paper-text-field-input-color, --primary-text-color);
-
       }
 
       /* We manage the focus UI separately */
@@ -86,9 +85,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         color: var(--paper-text-field-color, --secondary-text-color);
         @apply(--paper-font-common-nowrap);
         @apply(--paper-font-subhead);
-
-        transition-duration: .2s;
-        transition-timing-function: cubic-bezier(.4,0,.2,1);
       }
 
       :host([no-float-label]) label {
@@ -98,7 +94,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       label.label-is-floating {
         font-size: 12px;
         top: 0px;
-        visibility: visible;
       }
 
       label.label-is-hidden {
@@ -109,14 +104,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         color: var(--paper-text-field-focus-color, --primary-color);
       }
 
-      :host([focused]) label:after {
-        left: 0;
-        visibility: visible;
-        width: 100%;
-      }
-
-      /* The focused underline */
-      :host label:after {
+      /* Sets up the underline. It's initially hidden, and becomes visible when
+        it's focused. */
+      label:after {
         background-color: var(--paper-text-field-focus-color, --primary-color);
         bottom: 8px;
         content: '';
@@ -127,6 +117,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         transition-timing-function: cubic-bezier(.4,0,.2,1);
         visibility: hidden;
         width: 8px;
+        z-index: 10;
       }
+
+      :host([focused]) label:after {
+        left: 0;
+        visibility: visible;
+        width: 100%;
+      }
+
     </style>
 </dom-module>

--- a/paper-text-field-shared-styles.html
+++ b/paper-text-field-shared-styles.html
@@ -41,6 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #input {
+        @apply(--paper-font-subhead);
         position: relative; /* to make a stacking context */
         outline: none;
         box-shadow: none;
@@ -49,7 +50,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin: 0;
         padding: 12px 0 0 0;
         width: 100%;
-        @apply(--paper-font-subhead);
         text-align: inherit;
         line-height: inherit;
         background: 0 0;
@@ -66,11 +66,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       label {
+        @apply(--paper-font-common-nowrap);
+        @apply(--paper-font-subhead);
         position: absolute;
         bottom: 0;
         left: 0;
         right: 0;
-        top: 16px;
+        top: 18px;
 
         pointer-events: none;
 
@@ -83,8 +85,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         transition-timing-function: cubic-bezier(.4,0,.2,1);
 
         color: var(--paper-text-field-color, --secondary-text-color);
-        @apply(--paper-font-common-nowrap);
-        @apply(--paper-font-subhead);
       }
 
       :host([no-float-label]) label {

--- a/paper-text-field.html
+++ b/paper-text-field.html
@@ -43,34 +43,34 @@ Custom property | Description | Default
 -->
 
 <dom-module id="paper-text-field">
+  <style include="paper-text-field-shared-styles">
+  </style>
   <style>
     /* Prevent new lines from being entered or pasted */
     #input {
-        white-space: nowrap;
-        overflow: hidden;
+      min-height: 24px; /* FF doesn't seem to have a default */
+      z-index: 1;
+      white-space: nowrap;
+      overflow: hidden;
     }
-    #input br {
-        display: none;
+
+    /* The ::content rule is needed because in the shady DOM, the
+    brs are added by the browser and not style-scoped correctly. */
+    #input br, #input ::content br  {
+      display: none;
     }
-    #input * {
-        display: inline;
-        white-space: nowrap;
+
+    #input *, #input ::content * {
+      display: inline;
+      white-space: nowrap;
     }
   </style>
   <template>
-    <style include="paper-text-field-shared-styles"></style>
 
-    <div class="floated-label-placeholder" hidden$="[[noFloatLabel]]">&nbsp;</div>
-
-    <div class="input-content">
+    <div class="container">
       <label hidden$="[[!label]]"
-             class$="[[_computeLabelClass(noFloatLabel,alwaysFloatLabel,focused,hasContent)]]">[[label]]</label>
+          class$="[[_computeLabelClass(noFloatLabel,alwaysFloatLabel,hasContent)]]">[[label]]</label>
       <div id="input" contenteditable="true" tabindex="-1"></div>
-    </div>
-
-    <div class$="underline [[_computeUnderlineClass(focused)]]">
-      <div class="unfocused-line"></div>
-      <div class="focused-line"></div>
     </div>
 
   </template>
@@ -117,7 +117,6 @@ Custom property | Description | Default
       // Allow the pasted text and update the labels.
       document.execCommand('insertText', true, pastedText);
       this._onInput();
-      event.preventDefault();
     },
 
     /**

--- a/paper-text-field.html
+++ b/paper-text-field.html
@@ -109,15 +109,27 @@ Custom property | Description | Default
      */
     _onPaste: function(event) {
       var pastedText;
+
       if (window.clipboardData && window.clipboardData.getData) { // IE
         pastedText = window.clipboardData.getData('Text');
       } else if (event.clipboardData && event.clipboardData.getData) {
         pastedText = event.clipboardData.getData('text/plain');
       }
+
+      // IE10 and 11 don't support `insertText`, but support `paste`, which
+      // doesn't persist formatting. Modern browsers that support `insertText`
+      // also persist the formatting on `paste`, so they should use that.
+      if (document.queryCommandSupported('insertText')) {
+        document.execCommand('insertText', false, pastedText);
+      } else if (document.queryCommandSupported('paste')) {
+        document.execCommand('paste', false, pastedText);
+      } else {
+        return;
+      }
+
       // Allow the pasted text and update the labels.
-      document.execCommand('insertText', false, pastedText);
-      this._onInput();
       event.preventDefault();
+      this._onInput();
     },
 
     /**

--- a/paper-text-field.html
+++ b/paper-text-field.html
@@ -117,6 +117,7 @@ Custom property | Description | Default
       // Allow the pasted text and update the labels.
       document.execCommand('insertText', false, pastedText);
       this._onInput();
+      event.preventDefault();
     },
 
     /**

--- a/paper-text-field.html
+++ b/paper-text-field.html
@@ -48,7 +48,7 @@ Custom property | Description | Default
   <style>
     /* Prevent new lines from being entered or pasted */
     #input {
-      min-height: 24px; /* FF doesn't seem to have a default */
+      min-height: 20px; /* FF doesn't seem to have a default */
       z-index: 1;
       white-space: nowrap;
       overflow: hidden;

--- a/paper-text-field.html
+++ b/paper-text-field.html
@@ -115,7 +115,7 @@ Custom property | Description | Default
         pastedText = event.clipboardData.getData('text/plain');
       }
       // Allow the pasted text and update the labels.
-      document.execCommand('insertText', true, pastedText);
+      document.execCommand('insertText', false, pastedText);
       this._onInput();
     },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -84,10 +84,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('pasting', function(done) {
+      function ensureDocumentHasFocus() {
+        window.top && window.top.focus();
+      }
+
       test('pasting plain text', function(done) {
         input = fixture('basic');
 
+        // In FF, the tests steal focus from the window, which means we can't paste.
+        ensureDocumentHasFocus();
         MockInteractions.focus(input);
+
         var pasteEvent = new CustomEvent('paste');
         pasteEvent.clipboardData = { getData: function() { return 'batman'; } };
         input.inputElement.dispatchEvent(pasteEvent);
@@ -103,7 +110,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('pasting emoji', function(done) {
         input = fixture('basic');
 
+        // In FF, the tests steal focus from the window, which means we can't paste.
+        ensureDocumentHasFocus();
         MockInteractions.focus(input);
+
         var pasteEvent = new CustomEvent('paste');
         pasteEvent.clipboardData = { getData: function() { return '🌵'; } };
         input.inputElement.dispatchEvent(pasteEvent);
@@ -121,7 +131,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Note: this test is kind of moot, since pasting a bold thing actually
         // creates a text/html attribute, and text/plain is still the plain text
         // but you know. Sanity test or something.
+
+        // In FF, the tests steal focus from the window, which means we can't paste.
+        ensureDocumentHasFocus();
         MockInteractions.focus(input);
+
         var pasteEvent = new CustomEvent('paste');
         pasteEvent.clipboardData = { getData: function() { return '<b>batman</b>'; } };
         input.inputElement.dispatchEvent(pasteEvent);

--- a/test/basic.html
+++ b/test/basic.html
@@ -88,7 +88,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         window.top && window.top.focus();
       }
 
+      // On IE10 and IE11 pasting pops up an "Allow access" dialog, which
+      // we can't bypass (and means we can't run the tests).
+      var pasteRequiresUserInteraction;
+      setup(function() {
+        pasteRequiresUserInteraction = !document.queryCommandSupported('insertText');;
+      });
+
       test('pasting plain text', function(done) {
+        if (pasteRequiresUserInteraction) {
+          done();
+          return;
+        }
+
         input = fixture('basic');
 
         // In FF, the tests steal focus from the window, which means we can't paste.
@@ -104,10 +116,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
           done();
         }, 1);
+
       });
 
       // A potentially relevant test, because you know, unicode.
       test('pasting emoji', function(done) {
+        if (pasteRequiresUserInteraction) {
+          done();
+          return;
+        }
+
         input = fixture('basic');
 
         // In FF, the tests steal focus from the window, which means we can't paste.
@@ -119,6 +137,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         input.inputElement.dispatchEvent(pasteEvent);
 
         Polymer.Base.async(function(){
+
           assert.equal(input.value, '🌵', 'value is correct');
           assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
           done();
@@ -126,6 +145,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('pasting does not try to style', function(done) {
+        if (pasteRequiresUserInteraction) {
+          done();
+          return;
+        }
+
         input = fixture('basic');
 
         // Note: this test is kind of moot, since pasting a bold thing actually

--- a/test/basic.html
+++ b/test/basic.html
@@ -83,94 +83,76 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
-    suite('pasting', function(done) {
-      function ensureDocumentHasFocus() {
-        window.top && window.top.focus();
-      }
-
-      // On IE10 and IE11 pasting pops up an "Allow access" dialog, which
-      // we can't bypass (and means we can't run the tests).
-      var pasteRequiresUserInteraction;
-      setup(function() {
-        pasteRequiresUserInteraction = !document.queryCommandSupported('insertText');;
-      });
-
-      test('pasting plain text', function(done) {
-        if (pasteRequiresUserInteraction) {
-          done();
-          return;
+    // On IE10 and IE11 pasting pops up an "Allow access" dialog, which
+    // we can't bypass (and means we can't run the tests).
+    if (document.queryCommandSupported('insertText')) {
+      suite('pasting', function(done) {
+        function ensureDocumentHasFocus() {
+          window.top && window.top.focus();
         }
 
-        input = fixture('basic');
+        test('pasting plain text', function(done) {
+          input = fixture('basic');
 
-        // In FF, the tests steal focus from the window, which means we can't paste.
-        ensureDocumentHasFocus();
-        MockInteractions.focus(input);
+          // In FF, the tests steal focus from the window, which means we can't paste.
+          ensureDocumentHasFocus();
+          MockInteractions.focus(input);
 
-        var pasteEvent = new CustomEvent('paste');
-        window.clipboardData = pasteEvent.clipboardData = { getData: function() { return 'batman'; } };
-        input.inputElement.dispatchEvent(pasteEvent);
+          var pasteEvent = new CustomEvent('paste');
+          window.clipboardData = pasteEvent.clipboardData = { getData: function() { return 'batman'; } };
+          input.inputElement.dispatchEvent(pasteEvent);
 
-        Polymer.Base.async(function(){
-          assert.equal(input.value, 'batman', 'value is correct');
-          assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
-          done();
-        }, 1);
+          Polymer.Base.async(function(){
+            assert.equal(input.value, 'batman', 'value is correct');
+            assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
+            done();
+          }, 1);
 
+        });
+
+        // A potentially relevant test, because you know, unicode.
+        test('pasting emoji', function(done) {
+          input = fixture('basic');
+
+          // In FF, the tests steal focus from the window, which means we can't paste.
+          ensureDocumentHasFocus();
+          MockInteractions.focus(input);
+
+          var pasteEvent = new CustomEvent('paste');
+          window.clipboardData = pasteEvent.clipboardData = { getData: function() { return '🌵'; } };
+          input.inputElement.dispatchEvent(pasteEvent);
+
+          Polymer.Base.async(function(){
+
+            assert.equal(input.value, '🌵', 'value is correct');
+            assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
+            done();
+          }, 1);
+        });
+
+        test('pasting does not try to style', function(done) {
+          input = fixture('basic');
+
+          // Note: this test is kind of moot, since pasting a bold thing actually
+          // creates a text/html attribute, and text/plain is still the plain text
+          // but you know. Sanity test or something.
+
+          // In FF, the tests steal focus from the window, which means we can't paste.
+          ensureDocumentHasFocus();
+          MockInteractions.focus(input);
+
+          var pasteEvent = new CustomEvent('paste');
+          window.clipboardData = pasteEvent.clipboardData = { getData: function() { return '<b>batman</b>'; } };
+          input.inputElement.dispatchEvent(pasteEvent);
+
+          Polymer.Base.async(function() {
+            assert.equal(input.value, '<b>batman</b>', 'value is correct');
+            assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
+            done();
+          }, 1);
+        });
       });
-
-      // A potentially relevant test, because you know, unicode.
-      test('pasting emoji', function(done) {
-        if (pasteRequiresUserInteraction) {
-          done();
-          return;
-        }
-
-        input = fixture('basic');
-
-        // In FF, the tests steal focus from the window, which means we can't paste.
-        ensureDocumentHasFocus();
-        MockInteractions.focus(input);
-
-        var pasteEvent = new CustomEvent('paste');
-        window.clipboardData = pasteEvent.clipboardData = { getData: function() { return '🌵'; } };
-        input.inputElement.dispatchEvent(pasteEvent);
-
-        Polymer.Base.async(function(){
-
-          assert.equal(input.value, '🌵', 'value is correct');
-          assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
-          done();
-        }, 1);
-      });
-
-      test('pasting does not try to style', function(done) {
-        if (pasteRequiresUserInteraction) {
-          done();
-          return;
-        }
-
-        input = fixture('basic');
-
-        // Note: this test is kind of moot, since pasting a bold thing actually
-        // creates a text/html attribute, and text/plain is still the plain text
-        // but you know. Sanity test or something.
-
-        // In FF, the tests steal focus from the window, which means we can't paste.
-        ensureDocumentHasFocus();
-        MockInteractions.focus(input);
-
-        var pasteEvent = new CustomEvent('paste');
-        window.clipboardData = pasteEvent.clipboardData = { getData: function() { return '<b>batman</b>'; } };
-        input.inputElement.dispatchEvent(pasteEvent);
-
-        Polymer.Base.async(function() {
-          assert.equal(input.value, '<b>batman</b>', 'value is correct');
-          assert.equal(input.value, input.inputElement.textContent, 'value equals to textContent');
-          done();
-        }, 1);
-      });
-    });
+    }
 
     suite('focus/blur events', function() {
       var input;

--- a/test/basic.html
+++ b/test/basic.html
@@ -96,7 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.focus(input);
 
         var pasteEvent = new CustomEvent('paste');
-        pasteEvent.clipboardData = { getData: function() { return 'batman'; } };
+        window.clipboardData = pasteEvent.clipboardData = { getData: function() { return 'batman'; } };
         input.inputElement.dispatchEvent(pasteEvent);
 
         Polymer.Base.async(function(){
@@ -115,7 +115,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.focus(input);
 
         var pasteEvent = new CustomEvent('paste');
-        pasteEvent.clipboardData = { getData: function() { return '🌵'; } };
+        window.clipboardData = pasteEvent.clipboardData = { getData: function() { return '🌵'; } };
         input.inputElement.dispatchEvent(pasteEvent);
 
         Polymer.Base.async(function(){
@@ -137,7 +137,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.focus(input);
 
         var pasteEvent = new CustomEvent('paste');
-        pasteEvent.clipboardData = { getData: function() { return '<b>batman</b>'; } };
+        window.clipboardData = pasteEvent.clipboardData = { getData: function() { return '<b>batman</b>'; } };
         input.inputElement.dispatchEvent(pasteEvent);
 
         Polymer.Base.async(function() {

--- a/test/styles.html
+++ b/test/styles.html
@@ -110,10 +110,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(window.getComputedStyle(label, ':after').visibility,
             'hidden');
 
-        MockInteractions.focus(input.$.input);
-
-        // Wait for the animation to finish
-        setTimeout(function() {
+        var onTransitionEnd = function() {
           assert.isTrue(input.focused);
 
           // Should be highlighted.
@@ -122,8 +119,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               'rgb(63, 81, 181)');
           assert.equal(window.getComputedStyle(label, ':after').visibility,
               'visible');
+          // When the test cleans up, it will de-focus the input, which has another
+          // CSS transion. We don't care about that one.
+          input.removeEventListener('transitionend', onTransitionEnd);
           done();
-        }, 200);
+        }
+
+        // Wait for the animation to finish
+        input.addEventListener('transitionend', onTransitionEnd);
+        MockInteractions.focus(input.$.input);
       });
     });
   </script>

--- a/test/styles.html
+++ b/test/styles.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <test-fixture id="label">
+  <test-fixture id="just-label">
     <template>
       <paper-text-field label="batman"></paper-text-field>
     </template>
@@ -59,7 +59,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var input;
 
       test('label floats after user input', function() {
-        var input = fixture('label');
+        var input = fixture('just-label');
         var label = Polymer.dom(input.root).querySelector('label');
         assert.isFalse(label.classList.contains('label-is-floating'), 'label is not floating');
 
@@ -99,21 +99,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('focused styles', function() {
-      test('underline and label are colored when input is focused', function(done) {
+      test('label is colored when input is focused', function(done) {
         var input = fixture('label-and-value');
-        var line = Polymer.dom(input.root).querySelector('.underline');
         var label = Polymer.dom(input.root).querySelector('label');
 
-        assert.isFalse(line.classList.contains('is-highlighted'), 'line is not highlighted when input is not focused');
-        assert.isFalse(label.classList.contains('label-is-highlighted'), 'label is not highlighted when input is not focused');
+        assert.isFalse(input.focused);
+
+        // Nothing is coloured and the focus underline isn't showing
+        assert.equal(window.getComputedStyle(label).color, 'rgb(115, 115, 115)');
+        assert.equal(window.getComputedStyle(label, ':after').visibility,
+            'hidden');
 
         MockInteractions.focus(input.$.input);
 
-        requestAnimationFrame(function() {
-          assert.isTrue(line.classList.contains('is-highlighted'), 'line is highlighted when input is focused');
-          assert.isTrue(label.classList.contains('label-is-highlighted'), 'label is highlighted when input is focused');
+        // Wait for the animation to finish
+        setTimeout(function() {
+          assert.isTrue(input.focused);
+
+          // Should be highlighted.
+          assert.equal(window.getComputedStyle(label).color, 'rgb(63, 81, 181)');
+          assert.equal(window.getComputedStyle(label, ':after').backgroundColor,
+              'rgb(63, 81, 181)');
+          assert.equal(window.getComputedStyle(label, ':after').visibility,
+              'visible');
           done();
-        });
+        }, 200);
       });
     });
   </script>


### PR DESCRIPTION
MDL has a waaaay smaller DOM for its paper inputs than we do, so let's use theirs. 

/cc @addyosmani 

Also, lookie, it looks the same:
<img width="331" alt="screen shot 2016-03-03 at 11 57 05 am" src="https://cloud.githubusercontent.com/assets/1369170/13481130/13539ff4-e137-11e5-943e-842a857c48a9.png">
